### PR TITLE
Add NetDeskInfo WPF app (UI, services, viewmodels, models, helpers and build scripts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/bin/
+**/obj/
+.vs/
+*.user
+*.suo

--- a/NetDeskInfo.sln
+++ b/NetDeskInfo.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetDeskInfo", "NetDeskInfo\NetDeskInfo.csproj", "{A3D6F5B0-2C95-4A8D-8B4F-0FA1377F316A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A3D6F5B0-2C95-4A8D-8B4F-0FA1377F316A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3D6F5B0-2C95-4A8D-8B4F-0FA1377F316A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3D6F5B0-2C95-4A8D-8B4F-0FA1377F316A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3D6F5B0-2C95-4A8D-8B4F-0FA1377F316A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/NetDeskInfo/App.xaml
+++ b/NetDeskInfo/App.xaml
@@ -1,0 +1,73 @@
+<Application x:Class="NetDeskInfo.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+        <Color x:Key="WindowBackgroundColor">#FF0B1020</Color>
+        <Color x:Key="CardBackgroundColor">#FF151C33</Color>
+        <Color x:Key="AccentBlueColor">#FF36C4FF</Color>
+        <Color x:Key="AccentPurpleColor">#FF8C6CFF</Color>
+        <Color x:Key="SuccessColor">#FF21C785</Color>
+        <Color x:Key="WarningColor">#FFFFB020</Color>
+        <Color x:Key="ErrorColor">#FFFF4D6D</Color>
+        <Color x:Key="TextPrimaryColor">#FFF6F8FF</Color>
+        <Color x:Key="TextSecondaryColor">#FFA0ABC8</Color>
+
+        <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
+        <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
+        <SolidColorBrush x:Key="AccentBlueBrush" Color="{StaticResource AccentBlueColor}" />
+        <SolidColorBrush x:Key="AccentPurpleBrush" Color="{StaticResource AccentPurpleColor}" />
+        <SolidColorBrush x:Key="TextPrimaryBrush" Color="{StaticResource TextPrimaryColor}" />
+        <SolidColorBrush x:Key="TextSecondaryBrush" Color="{StaticResource TextSecondaryColor}" />
+        <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+
+        <Style TargetType="Window">
+            <Setter Property="Background" Value="{StaticResource WindowBackgroundBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}" />
+            <Setter Property="FontFamily" Value="Segoe UI" />
+        </Style>
+
+        <Style x:Key="CardBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+            <Setter Property="CornerRadius" Value="16" />
+            <Setter Property="Padding" Value="16" />
+            <Setter Property="Margin" Value="8" />
+            <Setter Property="Effect">
+                <Setter.Value>
+                    <DropShadowEffect BlurRadius="18" ShadowDepth="0" Opacity="0.25" Color="#FF000000"/>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Padding" Value="14,8"/>
+            <Setter Property="Margin" Value="4"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Background" Value="{StaticResource AccentBlueBrush}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="RootBorder" Background="{TemplateBinding Background}" CornerRadius="10">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="RootBorder" Property="Background" Value="{StaticResource AccentPurpleBrush}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="RootBorder" Property="Opacity" Value="0.5" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="SecondaryButtonStyle" TargetType="Button" BasedOn="{StaticResource PrimaryButtonStyle}">
+            <Setter Property="Background" Value="#FF2A3458" />
+        </Style>
+    </Application.Resources>
+</Application>

--- a/NetDeskInfo/App.xaml.cs
+++ b/NetDeskInfo/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace NetDeskInfo;
+
+public partial class App : Application
+{
+}

--- a/NetDeskInfo/Converters/HexToBrushConverter.cs
+++ b/NetDeskInfo/Converters/HexToBrushConverter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace NetDeskInfo.Converters;
+
+public sealed class HexToBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string hex)
+        {
+            return (SolidColorBrush)new BrushConverter().ConvertFromString(hex)!;
+        }
+
+        return Brushes.Gray;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => Binding.DoNothing;
+}

--- a/NetDeskInfo/Helpers/AsyncRelayCommand.cs
+++ b/NetDeskInfo/Helpers/AsyncRelayCommand.cs
@@ -1,0 +1,36 @@
+using System.Windows.Input;
+
+namespace NetDeskInfo.Helpers;
+
+public sealed class AsyncRelayCommand(Func<Task> execute, Func<bool>? canExecute = null) : ICommand
+{
+    private readonly Func<Task> _execute = execute;
+    private readonly Func<bool>? _canExecute = canExecute;
+    private bool _isRunning;
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => !_isRunning && (_canExecute?.Invoke() ?? true);
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        _isRunning = true;
+        RaiseCanExecuteChanged();
+        try
+        {
+            await _execute();
+        }
+        finally
+        {
+            _isRunning = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/NetDeskInfo/Helpers/ObservableObject.cs
+++ b/NetDeskInfo/Helpers/ObservableObject.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace NetDeskInfo.Helpers;
+
+public abstract class ObservableObject : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(storage, value))
+        {
+            return false;
+        }
+
+        storage = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        return true;
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/NetDeskInfo/Helpers/RelayCommand.cs
+++ b/NetDeskInfo/Helpers/RelayCommand.cs
@@ -1,0 +1,17 @@
+using System.Windows.Input;
+
+namespace NetDeskInfo.Helpers;
+
+public sealed class RelayCommand(Action<object?> execute, Func<object?, bool>? canExecute = null) : ICommand
+{
+    private readonly Action<object?> _execute = execute;
+    private readonly Func<object?, bool>? _canExecute = canExecute;
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
+
+    public void Execute(object? parameter) => _execute(parameter);
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/NetDeskInfo/MainWindow.xaml
+++ b/NetDeskInfo/MainWindow.xaml
@@ -1,0 +1,184 @@
+<Window x:Class="NetDeskInfo.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:conv="clr-namespace:NetDeskInfo.Converters"
+        mc:Ignorable="d"
+        Title="NetDeskInfo - Monitor de Rede e Sistema"
+        Width="1220"
+        Height="760"
+        MinWidth="980"
+        MinHeight="660"
+        WindowStartupLocation="CenterScreen">
+    <Window.Resources>
+        <conv:HexToBrushConverter x:Key="HexToBrushConverter"/>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility"/>
+
+        <Style x:Key="LabelTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Margin" Value="0,8,0,2" />
+        </Style>
+
+        <Style x:Key="ValueTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="16" Opacity="0">
+        <Grid.Triggers>
+            <EventTrigger RoutedEvent="FrameworkElement.Loaded">
+                <BeginStoryboard>
+                    <Storyboard>
+                        <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0" To="1" Duration="0:0:0.35" />
+                    </Storyboard>
+                </BeginStoryboard>
+            </EventTrigger>
+        </Grid.Triggers>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Style="{StaticResource CardBorderStyle}">
+            <DockPanel>
+                <StackPanel Orientation="Vertical" DockPanel.Dock="Left">
+                    <TextBlock FontSize="28" FontWeight="Bold" Text="🛰️ NetDeskInfo" />
+                    <TextBlock Foreground="{StaticResource TextSecondaryBrush}" Text="Informações de rede, localização e sistema em tempo real." />
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource PrimaryButtonStyle}" Content="🔄 Atualizar dados" Command="{Binding RefreshDataCommand}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource CardBorderStyle}">
+                    <StackPanel>
+                        <TextBlock FontSize="20" FontWeight="SemiBold" Text="🌐 Rede" />
+
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="IP público"/>
+                        <DockPanel>
+                            <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding PublicIp}" DockPanel.Dock="Left"/>
+                            <Button Style="{StaticResource SecondaryButtonStyle}" Content="Copiar" Command="{Binding CopyCommand}" CommandParameter="{Binding PublicIp}" HorizontalAlignment="Right" />
+                        </DockPanel>
+
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="IPv4 público"/>
+                        <DockPanel>
+                            <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding PublicIpv4}"/>
+                            <Button Style="{StaticResource SecondaryButtonStyle}" Content="Copiar" Command="{Binding CopyCommand}" CommandParameter="{Binding PublicIpv4}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="IPv6 público"/>
+                        <DockPanel>
+                            <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding PublicIpv6}"/>
+                            <Button Style="{StaticResource SecondaryButtonStyle}" Content="Copiar" Command="{Binding CopyCommand}" CommandParameter="{Binding PublicIpv6}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="IP local"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding LocalIp}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Máscara de rede"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Netmask}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Gateway"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Gateway}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Adaptador"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding AdapterName}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="DNS"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding DnsServers}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Status da conexão"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding ConnectionStatus}"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="0" Grid.Column="1" Style="{StaticResource CardBorderStyle}">
+                    <StackPanel>
+                        <TextBlock FontSize="20" FontWeight="SemiBold" Text="📍 Localização aproximada" />
+                        <TextBlock Foreground="{StaticResource WarningBrush}" Text="{Binding ApproximationNote}" Margin="0,6,0,8"/>
+
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="País"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Country}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Estado / Região"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Region}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Cidade"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding City}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="CEP"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding PostalCode}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Latitude / Longitude"/>
+                        <DockPanel>
+                            <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Latitude}" />
+                            <TextBlock Style="{StaticResource ValueTextStyle}" Text=", " Margin="4,0" />
+                            <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Longitude}" />
+                            <Button Style="{StaticResource SecondaryButtonStyle}" Content="Copiar" HorizontalAlignment="Right"
+                                    Command="{Binding CopyCommand}" CommandParameter="{Binding LocationSummary}"/>
+                        </DockPanel>
+
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Fuso horário"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Timezone}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="ISP / Provedor"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Isp}"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="1" Grid.Column="0" Style="{StaticResource CardBorderStyle}">
+                    <StackPanel>
+                        <TextBlock FontSize="20" FontWeight="SemiBold" Text="💻 Sistema" />
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Sistema operacional"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding OperatingSystem}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Versão"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding OsVersion}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Build"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Build}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Arquitetura"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Architecture}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Nome da máquina"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding MachineName}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Usuário atual"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding UserName}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Tempo ligado"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Uptime}"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource CardBorderStyle}">
+                    <StackPanel>
+                        <TextBlock FontSize="20" FontWeight="SemiBold" Text="🧩 Dispositivo" />
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Modelo"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding DeviceModel}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Processador"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding Processor}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="RAM total"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding TotalRam}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="RAM em uso"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding UsedRam}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Núcleos / Threads"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding CoresThreads}"/>
+                        <TextBlock Style="{StaticResource LabelTextStyle}" Text="Host"/>
+                        <TextBlock Style="{StaticResource ValueTextStyle}" Text="{Binding HostName}"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </ScrollViewer>
+
+        <Border Grid.Row="2" Style="{StaticResource CardBorderStyle}" Margin="8,12,8,0" Padding="12">
+            <DockPanel>
+                <TextBlock Text="{Binding StatusMessage}" Foreground="{Binding StatusColorHex, Converter={StaticResource HexToBrushConverter}}" FontWeight="SemiBold" />
+                <ProgressBar Width="180" Height="8" Margin="12,0,0,0" IsIndeterminate="True" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibility}}" />
+            </DockPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/NetDeskInfo/MainWindow.xaml.cs
+++ b/NetDeskInfo/MainWindow.xaml.cs
@@ -1,0 +1,30 @@
+using System.Net.Http;
+using System.Windows;
+using NetDeskInfo.Services;
+using NetDeskInfo.ViewModels;
+
+namespace NetDeskInfo;
+
+public partial class MainWindow : Window
+{
+    private readonly MainViewModel _viewModel;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        var sharedHttpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(8)
+        };
+
+        _viewModel = new MainViewModel(
+            new NetworkInfoService(sharedHttpClient),
+            new IpWhoIsGeolocationService(sharedHttpClient),
+            new SystemInfoService());
+
+        DataContext = _viewModel;
+
+        Loaded += async (_, _) => await _viewModel.RefreshAsync();
+    }
+}

--- a/NetDeskInfo/Models/DeviceInfoModel.cs
+++ b/NetDeskInfo/Models/DeviceInfoModel.cs
@@ -1,0 +1,11 @@
+namespace NetDeskInfo.Models;
+
+public sealed class DeviceInfoModel
+{
+    public string DeviceModel { get; init; } = "Não disponível";
+    public string Processor { get; init; } = "Não disponível";
+    public string TotalRam { get; init; } = "Não disponível";
+    public string UsedRam { get; init; } = "Não disponível";
+    public string CoresThreads { get; init; } = "Não disponível";
+    public string HostName { get; init; } = "Não disponível";
+}

--- a/NetDeskInfo/Models/LocationInfoModel.cs
+++ b/NetDeskInfo/Models/LocationInfoModel.cs
@@ -1,0 +1,14 @@
+namespace NetDeskInfo.Models;
+
+public sealed class LocationInfoModel
+{
+    public string Country { get; init; } = "Não disponível";
+    public string Region { get; init; } = "Não disponível";
+    public string City { get; init; } = "Não disponível";
+    public string PostalCode { get; init; } = "Não disponível";
+    public string Latitude { get; init; } = "Não disponível";
+    public string Longitude { get; init; } = "Não disponível";
+    public string Timezone { get; init; } = "Não disponível";
+    public string Isp { get; init; } = "Não disponível";
+    public string ApproximationNote { get; init; } = "A localização por IP é aproximada.";
+}

--- a/NetDeskInfo/Models/NetworkInfoModel.cs
+++ b/NetDeskInfo/Models/NetworkInfoModel.cs
@@ -1,0 +1,14 @@
+namespace NetDeskInfo.Models;
+
+public sealed class NetworkInfoModel
+{
+    public string PublicIp { get; init; } = "Não disponível";
+    public string PublicIpv4 { get; init; } = "Não disponível";
+    public string PublicIpv6 { get; init; } = "Não disponível";
+    public string LocalIp { get; init; } = "Não disponível";
+    public string Netmask { get; init; } = "Não disponível";
+    public string Gateway { get; init; } = "Não disponível";
+    public string AdapterName { get; init; } = "Não disponível";
+    public string DnsServers { get; init; } = "Não disponível";
+    public bool IsOnline { get; init; }
+}

--- a/NetDeskInfo/Models/SystemInfoModel.cs
+++ b/NetDeskInfo/Models/SystemInfoModel.cs
@@ -1,0 +1,12 @@
+namespace NetDeskInfo.Models;
+
+public sealed class SystemInfoModel
+{
+    public string OperatingSystem { get; init; } = "Não disponível";
+    public string OsVersion { get; init; } = "Não disponível";
+    public string Build { get; init; } = "Não disponível";
+    public string Architecture { get; init; } = "Não disponível";
+    public string MachineName { get; init; } = "Não disponível";
+    public string UserName { get; init; } = "Não disponível";
+    public string Uptime { get; init; } = "Não disponível";
+}

--- a/NetDeskInfo/NetDeskInfo.csproj
+++ b/NetDeskInfo/NetDeskInfo.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <RootNamespace>NetDeskInfo</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/NetDeskInfo/Services/IGeolocationService.cs
+++ b/NetDeskInfo/Services/IGeolocationService.cs
@@ -1,0 +1,8 @@
+using NetDeskInfo.Models;
+
+namespace NetDeskInfo.Services;
+
+public interface IGeolocationService
+{
+    Task<LocationInfoModel> GetLocationAsync(CancellationToken cancellationToken);
+}

--- a/NetDeskInfo/Services/INetworkInfoService.cs
+++ b/NetDeskInfo/Services/INetworkInfoService.cs
@@ -1,0 +1,8 @@
+using NetDeskInfo.Models;
+
+namespace NetDeskInfo.Services;
+
+public interface INetworkInfoService
+{
+    Task<NetworkInfoModel> GetNetworkInfoAsync(CancellationToken cancellationToken);
+}

--- a/NetDeskInfo/Services/ISystemInfoService.cs
+++ b/NetDeskInfo/Services/ISystemInfoService.cs
@@ -1,0 +1,9 @@
+using NetDeskInfo.Models;
+
+namespace NetDeskInfo.Services;
+
+public interface ISystemInfoService
+{
+    Task<SystemInfoModel> GetSystemInfoAsync(CancellationToken cancellationToken);
+    Task<DeviceInfoModel> GetDeviceInfoAsync(CancellationToken cancellationToken);
+}

--- a/NetDeskInfo/Services/IpWhoIsGeolocationService.cs
+++ b/NetDeskInfo/Services/IpWhoIsGeolocationService.cs
@@ -1,0 +1,72 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NetDeskInfo.Models;
+
+namespace NetDeskInfo.Services;
+
+/// <summary>
+/// Implementação de geolocalização por IP usando o provedor ipwho.is.
+/// Troque esta classe por outro provedor sem impactar a ViewModel.
+/// </summary>
+public sealed class IpWhoIsGeolocationService(HttpClient httpClient) : IGeolocationService
+{
+    private readonly HttpClient _httpClient = httpClient;
+
+    public async Task<LocationInfoModel> GetLocationAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await _httpClient.GetAsync("https://ipwho.is/", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new LocationInfoModel();
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            var payload = await JsonSerializer.DeserializeAsync<IpWhoIsResponse>(stream, cancellationToken: cancellationToken);
+            if (payload is null || !payload.Success)
+            {
+                return new LocationInfoModel();
+            }
+
+            return new LocationInfoModel
+            {
+                Country = payload.Country ?? "Não disponível",
+                Region = payload.Region ?? "Não disponível",
+                City = payload.City ?? "Não disponível",
+                PostalCode = payload.Postal ?? "Não disponível",
+                Latitude = payload.Latitude?.ToString("F4") ?? "Não disponível",
+                Longitude = payload.Longitude?.ToString("F4") ?? "Não disponível",
+                Timezone = payload.Timezone?.Id ?? "Não disponível",
+                Isp = payload.Connection?.Isp ?? "Não disponível"
+            };
+        }
+        catch (HttpRequestException)
+        {
+            return new LocationInfoModel();
+        }
+        catch (TaskCanceledException)
+        {
+            return new LocationInfoModel();
+        }
+        catch (JsonException)
+        {
+            return new LocationInfoModel();
+        }
+    }
+
+    private sealed record IpWhoIsResponse(
+        [property: JsonPropertyName("success")] bool Success,
+        [property: JsonPropertyName("country")] string? Country,
+        [property: JsonPropertyName("region") ] string? Region,
+        [property: JsonPropertyName("city")] string? City,
+        [property: JsonPropertyName("postal")] string? Postal,
+        [property: JsonPropertyName("latitude")] double? Latitude,
+        [property: JsonPropertyName("longitude")] double? Longitude,
+        [property: JsonPropertyName("timezone")] TimezoneDto? Timezone,
+        [property: JsonPropertyName("connection")] ConnectionDto? Connection);
+
+    private sealed record TimezoneDto([property: JsonPropertyName("id")] string? Id);
+    private sealed record ConnectionDto([property: JsonPropertyName("isp")] string? Isp);
+}

--- a/NetDeskInfo/Services/NetworkInfoService.cs
+++ b/NetDeskInfo/Services/NetworkInfoService.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using NetDeskInfo.Models;
+
+namespace NetDeskInfo.Services;
+
+public sealed class NetworkInfoService(HttpClient httpClient) : INetworkInfoService
+{
+    private readonly HttpClient _httpClient = httpClient;
+
+    public async Task<NetworkInfoModel> GetNetworkInfoAsync(CancellationToken cancellationToken)
+    {
+        var adapter = NetworkInterface
+            .GetAllNetworkInterfaces()
+            .Where(n => n.OperationalStatus == OperationalStatus.Up
+                        && n.NetworkInterfaceType != NetworkInterfaceType.Loopback)
+            .OrderByDescending(n => n.Speed)
+            .FirstOrDefault();
+
+        var localIp = "Não disponível";
+        var netmask = "Não disponível";
+        var gateway = "Não disponível";
+        var dnsServers = "Não disponível";
+
+        if (adapter is not null)
+        {
+            var properties = adapter.GetIPProperties();
+            var unicast = properties.UnicastAddresses
+                .FirstOrDefault(a => a.Address.AddressFamily == AddressFamily.InterNetwork);
+
+            localIp = unicast?.Address?.ToString() ?? "Não disponível";
+            netmask = unicast?.IPv4Mask?.ToString() ?? "Não disponível";
+            gateway = properties.GatewayAddresses
+                .FirstOrDefault(g => g.Address.AddressFamily == AddressFamily.InterNetwork)?.Address.ToString()
+                ?? "Não disponível";
+            dnsServers = string.Join(", ", properties.DnsAddresses.Select(d => d.ToString()).DefaultIfEmpty("Não disponível"));
+        }
+
+        var publicIpTask = TryGetAsync("https://api.ipify.org", cancellationToken);
+        var ipv4Task = TryGetAsync("https://api4.ipify.org", cancellationToken);
+        var ipv6Task = TryGetAsync("https://api6.ipify.org", cancellationToken);
+
+        await Task.WhenAll(publicIpTask, ipv4Task, ipv6Task);
+
+        return new NetworkInfoModel
+        {
+            PublicIp = publicIpTask.Result,
+            PublicIpv4 = ipv4Task.Result,
+            PublicIpv6 = ipv6Task.Result,
+            LocalIp = localIp,
+            Netmask = netmask,
+            Gateway = gateway,
+            AdapterName = adapter?.Name ?? "Não disponível",
+            DnsServers = dnsServers,
+            IsOnline = NetworkInterface.GetIsNetworkAvailable()
+        };
+    }
+
+    private async Task<string> TryGetAsync(string url, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await _httpClient.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return "Não disponível";
+            }
+
+            var value = await response.Content.ReadAsStringAsync(cancellationToken);
+            return string.IsNullOrWhiteSpace(value) ? "Não disponível" : value.Trim();
+        }
+        catch (HttpRequestException)
+        {
+            return "Não disponível";
+        }
+        catch (TaskCanceledException)
+        {
+            return "Não disponível";
+        }
+    }
+}

--- a/NetDeskInfo/Services/SystemInfoService.cs
+++ b/NetDeskInfo/Services/SystemInfoService.cs
@@ -1,0 +1,75 @@
+using System.Runtime.InteropServices;
+using Microsoft.VisualBasic.Devices;
+using Microsoft.Win32;
+using NetDeskInfo.Models;
+
+namespace NetDeskInfo.Services;
+
+public sealed class SystemInfoService : ISystemInfoService
+{
+    public Task<SystemInfoModel> GetSystemInfoAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var version = Environment.OSVersion.Version;
+        var uptime = TimeSpan.FromMilliseconds(Environment.TickCount64);
+
+        var model = new SystemInfoModel
+        {
+            OperatingSystem = RuntimeInformation.OSDescription,
+            OsVersion = version.ToString(),
+            Build = version.Build > 0 ? version.Build.ToString() : "Não disponível",
+            Architecture = RuntimeInformation.OSArchitecture.ToString(),
+            MachineName = Environment.MachineName,
+            UserName = Environment.UserName,
+            Uptime = $"{(int)uptime.TotalDays}d {uptime.Hours}h {uptime.Minutes}m"
+        };
+
+        return Task.FromResult(model);
+    }
+
+    public Task<DeviceInfoModel> GetDeviceInfoAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var computerInfo = new ComputerInfo();
+        var totalRamBytes = computerInfo.TotalPhysicalMemory;
+        var availableRamBytes = computerInfo.AvailablePhysicalMemory;
+        var usedRamBytes = totalRamBytes - availableRamBytes;
+
+        var model = new DeviceInfoModel
+        {
+            DeviceModel = ReadDeviceModel(),
+            Processor = GetProcessorName(),
+            TotalRam = FormatBytes(totalRamBytes),
+            UsedRam = FormatBytes(usedRamBytes),
+            CoresThreads = $"Lógicos: {Environment.ProcessorCount}",
+            HostName = System.Net.Dns.GetHostName()
+        };
+
+        return Task.FromResult(model);
+    }
+
+    private static string GetProcessorName()
+    {
+        // Busca o nome real da CPU no registro do Windows.
+        const string keyPath = @"HKEY_LOCAL_MACHINE\HARDWARE\DESCRIPTION\System\CentralProcessor\0";
+        return Registry.GetValue(keyPath, "ProcessorNameString", "Não disponível")?.ToString() ?? "Não disponível";
+    }
+
+    private static string ReadDeviceModel()
+    {
+        const string basePath = @"HKEY_LOCAL_MACHINE\HARDWARE\DESCRIPTION\System\BIOS";
+        var manufacturer = Registry.GetValue(basePath, "SystemManufacturer", null)?.ToString();
+        var product = Registry.GetValue(basePath, "SystemProductName", null)?.ToString();
+
+        var result = $"{manufacturer} {product}".Trim();
+        return string.IsNullOrWhiteSpace(result) ? "Não disponível" : result;
+    }
+
+    private static string FormatBytes(ulong bytes)
+    {
+        var value = bytes / 1024d / 1024d / 1024d;
+        return $"{value:F2} GB";
+    }
+}

--- a/NetDeskInfo/ViewModels/MainViewModel.cs
+++ b/NetDeskInfo/ViewModels/MainViewModel.cs
@@ -1,0 +1,271 @@
+using System.Windows;
+using System.Windows.Input;
+using NetDeskInfo.Helpers;
+using NetDeskInfo.Models;
+using NetDeskInfo.Services;
+
+namespace NetDeskInfo.ViewModels;
+
+public sealed class MainViewModel : ObservableObject
+{
+    private readonly INetworkInfoService _networkInfoService;
+    private readonly IGeolocationService _geolocationService;
+    private readonly ISystemInfoService _systemInfoService;
+
+    private string _statusMessage = "Pronto.";
+    private string _statusColorHex = "#21C785";
+    private bool _isLoading;
+
+    public MainViewModel(INetworkInfoService networkInfoService, IGeolocationService geolocationService, ISystemInfoService systemInfoService)
+    {
+        _networkInfoService = networkInfoService;
+        _geolocationService = geolocationService;
+        _systemInfoService = systemInfoService;
+
+        RefreshDataCommand = new AsyncRelayCommand(RefreshAsync, () => !IsLoading);
+        CopyCommand = new RelayCommand(CopyValue);
+    }
+
+    public ICommand RefreshDataCommand { get; }
+    public ICommand CopyCommand { get; }
+
+    public bool IsLoading
+    {
+        get => _isLoading;
+        set
+        {
+            if (!SetProperty(ref _isLoading, value))
+            {
+                return;
+            }
+
+            OnPropertyChanged(nameof(IsNotLoading));
+        }
+    }
+
+    public bool IsNotLoading => !IsLoading;
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        set => SetProperty(ref _statusMessage, value);
+    }
+
+    public string StatusColorHex
+    {
+        get => _statusColorHex;
+        set => SetProperty(ref _statusColorHex, value);
+    }
+
+    // Rede
+    public string PublicIp { get; private set; } = "Não disponível";
+    public string PublicIpv4 { get; private set; } = "Não disponível";
+    public string PublicIpv6 { get; private set; } = "Não disponível";
+    public string LocalIp { get; private set; } = "Não disponível";
+    public string Netmask { get; private set; } = "Não disponível";
+    public string Gateway { get; private set; } = "Não disponível";
+    public string AdapterName { get; private set; } = "Não disponível";
+    public string DnsServers { get; private set; } = "Não disponível";
+    public string ConnectionStatus { get; private set; } = "Desconhecido";
+
+    // Localização
+    public string Country { get; private set; } = "Não disponível";
+    public string Region { get; private set; } = "Não disponível";
+    public string City { get; private set; } = "Não disponível";
+    public string PostalCode { get; private set; } = "Não disponível";
+    public string Latitude { get; private set; } = "Não disponível";
+    public string Longitude { get; private set; } = "Não disponível";
+    public string Timezone { get; private set; } = "Não disponível";
+    public string Isp { get; private set; } = "Não disponível";
+    public string ApproximationNote { get; private set; } = "A localização por IP é aproximada.";
+    public string LocationSummary => $"{City}, {Region}, {Country} ({Latitude}, {Longitude})";
+
+    // Sistema
+    public string OperatingSystem { get; private set; } = "Não disponível";
+    public string OsVersion { get; private set; } = "Não disponível";
+    public string Build { get; private set; } = "Não disponível";
+    public string Architecture { get; private set; } = "Não disponível";
+    public string MachineName { get; private set; } = "Não disponível";
+    public string UserName { get; private set; } = "Não disponível";
+    public string Uptime { get; private set; } = "Não disponível";
+
+    // Dispositivo
+    public string DeviceModel { get; private set; } = "Não disponível";
+    public string Processor { get; private set; } = "Não disponível";
+    public string TotalRam { get; private set; } = "Não disponível";
+    public string UsedRam { get; private set; } = "Não disponível";
+    public string CoresThreads { get; private set; } = "Não disponível";
+    public string HostName { get; private set; } = "Não disponível";
+
+    public async Task RefreshAsync()
+    {
+        IsLoading = true;
+        StatusMessage = "Carregando dados do sistema e da rede...";
+        StatusColorHex = "#36C4FF";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+
+        var networkTask = SafeLoadAsync(() => _networkInfoService.GetNetworkInfoAsync(cts.Token));
+        var locationTask = SafeLoadAsync(() => _geolocationService.GetLocationAsync(cts.Token));
+        var systemTask = SafeLoadAsync(() => _systemInfoService.GetSystemInfoAsync(cts.Token));
+        var deviceTask = SafeLoadAsync(() => _systemInfoService.GetDeviceInfoAsync(cts.Token));
+
+        await Task.WhenAll(networkTask, locationTask, systemTask, deviceTask);
+
+        var warnings = 0;
+
+        if (networkTask.Result is { } network)
+        {
+            PublicIp = network.PublicIp;
+            PublicIpv4 = network.PublicIpv4;
+            PublicIpv6 = network.PublicIpv6;
+            LocalIp = network.LocalIp;
+            Netmask = network.Netmask;
+            Gateway = network.Gateway;
+            AdapterName = network.AdapterName;
+            DnsServers = network.DnsServers;
+            ConnectionStatus = network.IsOnline ? "Online" : "Offline";
+        }
+        else
+        {
+            warnings++;
+        }
+
+        if (locationTask.Result is { } location)
+        {
+            Country = location.Country;
+            Region = location.Region;
+            City = location.City;
+            PostalCode = location.PostalCode;
+            Latitude = location.Latitude;
+            Longitude = location.Longitude;
+            Timezone = location.Timezone;
+            Isp = location.Isp;
+            ApproximationNote = location.ApproximationNote;
+        }
+        else
+        {
+            warnings++;
+        }
+
+        if (systemTask.Result is { } system)
+        {
+            OperatingSystem = system.OperatingSystem;
+            OsVersion = system.OsVersion;
+            Build = system.Build;
+            Architecture = system.Architecture;
+            MachineName = system.MachineName;
+            UserName = system.UserName;
+            Uptime = system.Uptime;
+        }
+        else
+        {
+            warnings++;
+        }
+
+        if (deviceTask.Result is { } device)
+        {
+            DeviceModel = device.DeviceModel;
+            Processor = device.Processor;
+            TotalRam = device.TotalRam;
+            UsedRam = device.UsedRam;
+            CoresThreads = device.CoresThreads;
+            HostName = device.HostName;
+        }
+        else
+        {
+            warnings++;
+        }
+
+        NotifyAllDataProperties();
+
+        if (warnings == 0)
+        {
+            StatusMessage = "Dados atualizados com sucesso.";
+            StatusColorHex = "#21C785";
+        }
+        else if (warnings < 4)
+        {
+            StatusMessage = "Dados atualizados parcialmente. Alguns itens não estavam disponíveis no momento.";
+            StatusColorHex = "#FFB020";
+        }
+        else
+        {
+            StatusMessage = "Não foi possível carregar os dados agora. Tente novamente em instantes.";
+            StatusColorHex = "#FF4D6D";
+        }
+
+        IsLoading = false;
+    }
+
+    private static async Task<T?> SafeLoadAsync<T>(Func<Task<T>> action) where T : class
+    {
+        try
+        {
+            return await action();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void CopyValue(object? parameter)
+    {
+        var content = parameter?.ToString();
+        if (string.IsNullOrWhiteSpace(content) || content == "Não disponível")
+        {
+            StatusMessage = "Nada para copiar.";
+            StatusColorHex = "#FFB020";
+            return;
+        }
+
+        try
+        {
+            Clipboard.SetText(content);
+            StatusMessage = "Conteúdo copiado para a área de transferência.";
+            StatusColorHex = "#21C785";
+        }
+        catch
+        {
+            StatusMessage = "Não foi possível copiar no momento.";
+            StatusColorHex = "#FF4D6D";
+        }
+    }
+
+    private void NotifyAllDataProperties()
+    {
+        OnPropertyChanged(nameof(PublicIp));
+        OnPropertyChanged(nameof(PublicIpv4));
+        OnPropertyChanged(nameof(PublicIpv6));
+        OnPropertyChanged(nameof(LocalIp));
+        OnPropertyChanged(nameof(Netmask));
+        OnPropertyChanged(nameof(Gateway));
+        OnPropertyChanged(nameof(AdapterName));
+        OnPropertyChanged(nameof(DnsServers));
+        OnPropertyChanged(nameof(ConnectionStatus));
+        OnPropertyChanged(nameof(Country));
+        OnPropertyChanged(nameof(Region));
+        OnPropertyChanged(nameof(City));
+        OnPropertyChanged(nameof(PostalCode));
+        OnPropertyChanged(nameof(Latitude));
+        OnPropertyChanged(nameof(Longitude));
+        OnPropertyChanged(nameof(Timezone));
+        OnPropertyChanged(nameof(Isp));
+        OnPropertyChanged(nameof(ApproximationNote));
+        OnPropertyChanged(nameof(LocationSummary));
+        OnPropertyChanged(nameof(OperatingSystem));
+        OnPropertyChanged(nameof(OsVersion));
+        OnPropertyChanged(nameof(Build));
+        OnPropertyChanged(nameof(Architecture));
+        OnPropertyChanged(nameof(MachineName));
+        OnPropertyChanged(nameof(UserName));
+        OnPropertyChanged(nameof(Uptime));
+        OnPropertyChanged(nameof(DeviceModel));
+        OnPropertyChanged(nameof(Processor));
+        OnPropertyChanged(nameof(TotalRam));
+        OnPropertyChanged(nameof(UsedRam));
+        OnPropertyChanged(nameof(CoresThreads));
+        OnPropertyChanged(nameof(HostName));
+    }
+}

--- a/NetDeskInfo/build-exe.bat
+++ b/NetDeskInfo/build-exe.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+REM Build and publish NetDeskInfo as Windows executable
+cd /d %~dp0
+
+echo [1/3] Restoring packages...
+dotnet restore
+if errorlevel 1 goto :error
+
+echo [2/3] Building Release...
+dotnet build -c Release
+if errorlevel 1 goto :error
+
+echo [3/3] Publishing Win-x64 (single-file)...
+dotnet publish -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+if errorlevel 1 goto :error
+
+echo.
+echo DONE. EXE em:
+echo %~dp0bin\Release\net8.0-windows\win-x64\publish\NetDeskInfo.exe
+exit /b 0
+
+:error
+echo Falha no processo de build/publicacao.
+exit /b 1

--- a/NetDeskInfo/build-exe.ps1
+++ b/NetDeskInfo/build-exe.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+Write-Host '[1/3] Restoring packages...'
+dotnet restore
+
+Write-Host '[2/3] Building Release...'
+dotnet build -c Release
+
+Write-Host '[3/3] Publishing Win-x64 (single-file)...'
+dotnet publish -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+
+Write-Host "`nDONE. EXE em: $PSScriptRoot\bin\Release\net8.0-windows\win-x64\publish\NetDeskInfo.exe"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# NetDeskInfo (WPF / .NET 8)
+
+Aplicativo desktop para Windows com interface moderna (tema escuro) para exibir informações de rede, localização aproximada por IP, sistema e dispositivo.
+
+## Estrutura
+
+- `NetDeskInfo/NetDeskInfo.csproj`: projeto WPF .NET 8.
+- `NetDeskInfo/MainWindow.xaml`: layout principal com cards/painéis.
+- `NetDeskInfo/ViewModels/MainViewModel.cs`: orquestra carregamento e comandos (MVVM).
+- `NetDeskInfo/Services/*`: serviços separados para rede, sistema e geolocalização.
+- `NetDeskInfo/Models/*`: modelos de dados por seção.
+- `NetDeskInfo/Helpers/*`: infraestrutura de comandos e notificação de propriedades.
+
+## Como gerar o .exe final no Windows
+
+Pré-requisitos:
+- Windows 10/11
+- .NET SDK 8
+
+### Opção rápida (recomendado)
+
+No `Prompt de Comando`:
+
+```bat
+cd NetDeskInfo
+build-exe.bat
+```
+
+Ou no PowerShell:
+
+```powershell
+cd NetDeskInfo
+./build-exe.ps1
+```
+
+Saída final:
+
+`NetDeskInfo/bin/Release/net8.0-windows/win-x64/publish/NetDeskInfo.exe`
+
+## Comandos manuais (alternativa)
+
+```bash
+cd NetDeskInfo
+dotnet restore
+dotnet build -c Release
+dotnet publish -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+```
+
+## API de geolocalização
+
+A implementação atual usa `https://ipwho.is/` (`IpWhoIsGeolocationService`).
+A troca para outro provedor pode ser feita criando outra classe que implemente `IGeolocationService`.
+
+## Observações de UX implementadas
+
+- Carregamento automático ao abrir.
+- Botão de atualização manual.
+- Botões de cópia para IP público/IPv4/IPv6 e localização.
+- Barra de status com mensagens de carregamento/sucesso/aviso.
+- Tratamento de falhas parciais: se a API externa falhar, o app ainda mostra os dados locais normalmente.
+
+## Melhorias futuras sugeridas
+
+- Mostrar uso de RAM em tempo real com atualização periódica.
+- Exibir endereço MAC e velocidade do adaptador ativo.
+- Histórico de IP público com exportação em CSV.
+- Tela de configurações para trocar provedor de geolocalização sem recompilar.


### PR DESCRIPTION
### Motivation
- Provide a lightweight Windows desktop app that displays network, approximate IP geolocation, system and device information with a modern dark-themed WPF UI.
- Structure the app using MVVM and small service abstractions so external providers (geolocation, network) can be swapped without changing the UI layer.
- Improve UX with async loading, progress/status feedback, copy-to-clipboard and manual refresh commands.

### Description
- Add a new WPF project `NetDeskInfo` with `NetDeskInfo.csproj`, solution file and application entry (`App.xaml`, `App.xaml.cs`) plus `MainWindow.xaml` and `MainWindow.xaml.cs` for the UI and startup wiring.
- Implement `MainViewModel` with async refresh logic, `RefreshDataCommand` and `CopyCommand`, plus robust safe-loading (`SafeLoadAsync`) and status messaging/colouring.
- Add services and interfaces (`INetworkInfoService`, `IGeolocationService`, `ISystemInfoService`) and concrete implementations `NetworkInfoService`, `IpWhoIsGeolocationService` (uses `https://ipwho.is/`) and `SystemInfoService` for platform/system details.
- Add data models under `Models/*`, utility helpers (`ObservableObject`, `RelayCommand`, `AsyncRelayCommand`), a `HexToBrushConverter`, build scripts (`build-exe.bat`, `build-exe.ps1`), `.gitignore` and a `README.md` documenting build/publish steps.

### Testing
- No automated unit or integration tests were added or executed as part of this change.
- Build and publish scripts are provided (`build-exe.bat`, `build-exe.ps1`) to produce a self-contained Windows executable via `dotnet build` and `dotnet publish`, but these scripts were not run as automated tests in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b75b3011d4832d96920b3066cef566)